### PR TITLE
[opencc] allow to build on arm

### DIFF
--- a/ports/opencc/vcpkg.json
+++ b/ports/opencc/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "A project for conversions between Traditional Chinese, Simplified Chinese and Japanese Kanji (Shinjitai)",
   "homepage": "https://github.com/BYVoid/OpenCC",
   "license": "Apache-2.0",
-  "supports": "!(arm | uwp)",
+  "supports": "!(uwp)",
   "dependencies": [
     "darts-clone",
     "marisa-trie",


### PR DESCRIPTION
This package can be built on arm (I tested on macOS) today.

Homebrew has been providing Arm build of this package for a very long time https://formulae.brew.sh/formula/opencc